### PR TITLE
Changing QS iterator to be pk independent EON-1737

### DIFF
--- a/simple_elasticsearch/utils.py
+++ b/simple_elasticsearch/utils.py
@@ -216,18 +216,14 @@ def recursive_dict_update(d, u):
 
 
 def queryset_iterator(queryset, chunksize=1000):
-    try:
-        last_pk = queryset.order_by('-pk')[0].pk
-    except IndexError:
-        return
+    total = queryset.count()
+    row_ptr = 0
 
-    queryset = queryset.order_by('pk')
-    pk = queryset[0].pk - 1
-    while pk < last_pk:
-        for row in queryset.filter(pk__gt=pk)[:chunksize]:
-            pk = row.pk
+    while row_ptr < total:
+        for row in queryset[row_ptr:(row_ptr+chunksize)]:
             yield row
         gc.collect()
+        row_ptr += chunksize
 
 
 def get_from_es_or_None(index, type, id, **kwargs):


### PR DESCRIPTION
The original author looks to have used an older django snippet around [creating a memory efficient queryset](https://djangosnippets.org/snippets/1949/)

Django has some documentation on ways to [limit querysets](https://docs.djangoproject.com/en/1.7/topics/db/queries/#limiting-querysets)

I modified the original solution to do a count() on the queryset to retrieve the total number of items, and then used the slicing to limit the amount of items we are grabbing from the database to the specified chunksize.

There might be a way to craft a version of this without queryset caching using a [queryset iterator](https://docs.djangoproject.com/en/1.7/ref/models/querysets/#iterator) which is supposed to help address memory concerns when your operating over a large dataset once. In usage - the management command which updates the index should only be run once (when we migrate over to the new search code) and then the celery signals should maintain the index from that point on (without need to run the update index periodically like we were doing with haystack). Please review and let me know if you see any problems. 
